### PR TITLE
CI adaptation changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ terraform-provider-kubevirt
 *swp
 _examples/**/.terraform
 _ci-configs
+build/_output

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+make install
+
 make cluster-up	
 
 make functest

--- a/ci-tests/datavolume/stubs.go
+++ b/ci-tests/datavolume/stubs.go
@@ -1,8 +1,6 @@
 package datavolume
 
 import (
-	"fmt"
-
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +17,6 @@ func getExpectedDataVolume(name string, namespace string, source cdiv1.DataVolum
 			Name:         name,
 			GenerateName: "",
 			Namespace:    namespace,
-			SelfLink:     fmt.Sprintf("/apis/cdi.kubevirt.io/v1alpha1/namespaces/%s/datavolumes/%s", namespace, name),
 			Labels:       labels,
 		},
 		Spec: cdiv1.DataVolumeSpec{

--- a/scripts/func-test.sh
+++ b/scripts/func-test.sh
@@ -2,4 +2,4 @@
 
 export KUBECONFIG=$(cluster-up/kubeconfig.sh)
 
-go test ./ci-tests/... -timeout 99999s
+$GO test ./ci-tests/... -timeout 99999s

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -2,7 +2,7 @@
 
 # Check gofmt
 echo "==> Checking that code complies with gofmt requirements..."
-gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor`)
+gofmt_files=$($GOFMT -l `find . -name '*.go' | grep -v vendor | grep -v build`)
 if [[ -n ${gofmt_files} ]]; then
     echo 'gofmt needs running on the following files:'
     echo "${gofmt_files}"

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+destination=$1
+version=$(grep "^go " go.mod |awk '{print $2}')
+tarball=go$version.linux-amd64.tar.gz
+url=https://dl.google.com/go/
+
+mkdir -p $destination
+curl -L $url/$tarball -o $destination/$tarball
+tar -xf $destination/$tarball -C $destination

--- a/scripts/install-terraform.sh
+++ b/scripts/install-terraform.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+destination=$1
+version='0.12.0'
+base_url=https://releases.hashicorp.com/terraform/$version
+zip_file=terraform_${version}_linux_amd64.zip
+
+mkdir -p $destination
+curl -L $base_url/$zip_file -o $destination/$zip_file
+unzip -o $destination/$zip_file -d $destination


### PR DESCRIPTION
This repository was added to the ci tests
(PRs https://github.com/kubevirt/project-infra/pull/1241 and https://github.com/kubevirt/project-infra/pull/1246)
In the ci, the tests are executed in "kubevirt-ci" container
(https://github.com/kubevirt/project-infra/blob/54d9083d06c34c82145b7b07e8193de4b9376e37/github/ci/prow-deploy/files/jobs/kubevirt/terraform-provider-kubevirt/terraform-provider-kubevirt-presubmits.yaml#L28)
As result of that, needed to change the repository to install all
dependecies before running the tests:
* golang (go and gofmt)
* ginko and gomega
* terraform

Signed-off-by: Nir Argaman <nargaman@redhat.com>