### PR TITLE
Allow more than one network (Fixing #8)

### DIFF
--- a/kubevirt/schema/virtualmachineinstance/domain_spec.go
+++ b/kubevirt/schema/virtualmachineinstance/domain_spec.go
@@ -98,7 +98,7 @@ func domainSpecFields() map[string]*schema.Schema {
 					"interface": {
 						Type:        schema.TypeList,
 						Description: "Interfaces describe network interfaces which are added to the vmi.",
-						Required:    true,
+						Optional:    true,
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
 								"name": {

--- a/kubevirt/schema/virtualmachineinstance/networks.go
+++ b/kubevirt/schema/virtualmachineinstance/networks.go
@@ -70,7 +70,6 @@ func networksSchema() *schema.Schema {
 
 		Description: fmt.Sprintf("List of networks that can be attached to a vm's virtual interface."),
 		Optional:    true,
-		MaxItems:    1,
 		Elem: &schema.Resource{
 			Schema: fields,
 		},
@@ -122,7 +121,7 @@ func expandPodNetwork(pod []interface{}) *kubevirtapiv1.PodNetwork {
 	result := &kubevirtapiv1.PodNetwork{}
 
 	if len(pod) == 0 || pod[0] == nil {
-		return result
+		return nil
 	}
 
 	in := pod[0].(map[string]interface{})


### PR DESCRIPTION
Fixing the artificial schema limit of a single network.
Fixing the underlying reason : the code was adding a "pod" type to every network even if multus was explicitly requested